### PR TITLE
feat(.vscode): 添加 AI 大模型记忆文件折叠配置

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -17,7 +17,9 @@
     "README.md": "index.html,favicon.ico,robots.txt,CHANGELOG.md",
     "pages.config.ts": "manifest.config.ts,openapi-ts-request.config.ts",
     "package.json": "tsconfig.json,pnpm-lock.yaml,pnpm-workspace.yaml,LICENSE,.gitattributes,.gitignore,.gitpod.yml,CNAME,.npmrc,.browserslistrc",
-    "eslint.config.mjs": ".commitlintrc.*,.prettier*,.editorconfig,.commitlint.cjs,.eslint*"
+    "eslint.config.mjs": ".commitlintrc.*,.prettier*,.editorconfig,.commitlint.cjs,.eslint*",
+    // 折叠 AI大模型记忆文件
+    "CLAUDE.md": "GEMINI.md,AGENTS.md"
   },
 
   // Disable the default formatter, use eslint instead


### PR DESCRIPTION
## Summary
为 VSCode 添加文件资源管理器嵌套折叠配置，使得 AI 大模型记忆文件（`CLAUDE.md`、`GEMINI.md`、`AGENTS.md`）在文件树中自动折叠显示，提升开发体验。

## Changes
- 在 `.vscode/settings.json` 中添加 `explorer.fileNesting.patterns` 配置
- 配置 `CLAUDE.md` 嵌套显示 `GEMINI.md` 和 `AGENTS.md`

## Motivation
AI 大模型记忆文件通常成组出现，通过文件嵌套折叠可以：
1. 减少文件树中的视觉噪音
2. 更清晰地展示项目结构
3. 快速访问相关配置文件